### PR TITLE
Remove the hard-coded spec/jar files in poreseq_assemble and distribute these files by setup.py

### DIFF
--- a/scripts/poreseq_assemble
+++ b/scripts/poreseq_assemble
@@ -5,7 +5,9 @@ if [ $# -lt 1 ]; then
     exit
 fi
 
+DIR="$(python -c "import poreseq, os; print os.path.dirname(poreseq.__file__)")"
+
 # first, convert fasta file to fastq with blank qual
-java -jar ~/github/poreseq/scripts/convertFastaAndQualToFastq.jar $1 > $1.fastq
+java -jar $DIR/../resources/convertFastaAndQualToFastq.jar $1 > $1.fastq
 # next, call celera with custom spec file, passing through rest of arguments
-PBcR -length 500 -l assembly -s ~/github/poreseq/poreseq.spec -fastq $1.fastq  "${@:2}"
+PBcR -length 500 -l assembly -s $DIR/../resources/poreseq.spec -fastq $1.fastq  "${@:2}"

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,12 @@ setup(
     install_requires=["Cython>0.18","Biopython>1.6", "pysam>0.8.2", "h5py>2.0"],
     scripts=[
         'scripts/poreseq_align',
-        'scripts/poreseq_assemble'
+        'scripts/poreseq_assemble',
     ],
+    data_files=[
+        ('resources', ['poreseq.spec', 'scripts/convertFastaAndQualToFastq.jar']),
+    ],
+    zip_safe=False, # so that the resources can be fetched by the scripts
     entry_points={
         'console_scripts': [
             'poreseq = poreseq.cmdline:main',


### PR DESCRIPTION
The jar file and the spec file are hard-coded in poreseq_assemble, which causes errors on other users. I am suggesting to distribute these files as resource files along the python installation, and the shell script just finds the path of those files automatically.
